### PR TITLE
use https url to avoid ssh error

### DIFF
--- a/download-zkey.sh
+++ b/download-zkey.sh
@@ -1,4 +1,4 @@
-GIT_LFS_SKIP_SMUDGE=1 git clone git@github.com:sui-foundation/zklogin-ceremony-contributions.git
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/sui-foundation/zklogin-ceremony-contributions.git
 
 cd zklogin-ceremony-contributions
 


### PR DESCRIPTION
Fixes the publickey error when using the script:

`Cloning into 'zklogin-ceremony-contributions'...
The authenticity of host 'github.com (X.X.X.X)' can't be established.
ECDSA key fingerprint is SHA256:XXXXXXXXXXXXXX.
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added 'github.com,X.X.X.X' (ECDSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.`